### PR TITLE
Modifications for RHEL/CentOS 7

### DIFF
--- a/eni
+++ b/eni
@@ -151,7 +151,7 @@ eni_stop() {
         attachment_id=`/usr/bin/aws ec2 describe-network-interfaces --network-interface-ids ${OCF_RESKEY_interface_id} --filter "Name=attachment.instance-id, Values=${instance_id}" --output json | grep \"AttachmentId\": | sed -e 's/'.*\"AttachmentId\"':\s\"\(.*\)\"\,\s$/\1/'`
         /usr/bin/aws ec2 detach-network-interface --attachment-id ${attachment_id} 
         #sleep ${OCF_RESKEY_wait}
-	sleep 5
+	sleep 10
     fi
     return $OCF_SUCCESS
 }

--- a/eni
+++ b/eni
@@ -156,10 +156,6 @@ eni_start() {
     /usr/bin/aws ec2 attach-network-interface --network-interface-id ${OCF_RESKEY_interface_id} --instance-id ${instance_id} --device-index ${OCF_RESKEY_device_index}
     sleep ${OCF_RESKEY_wait}
 
-    #private_ip="10.0.106.25"
-    #private_ip_netmask="255.255.252.0"
-
-    #/sbin/ifconfig ${OCF_RESKEY_device_name} ${private_ip} netmask ${private_ip_netmask} up
     /sbin/ifconfig ${OCF_RESKEY_device_name} ${OCF_RESKEY_private_ip} netmask ${OCF_RESKEY_netmask} up
 
     #private_ip=`ifconfig ${OCF_RESKEY_device_name} | grep "inet addr:" | awk -F: '{ print $2 }' | awk '{ print $1 }'`
@@ -177,7 +173,6 @@ eni_stop() {
 	
         /usr/bin/aws ec2 detach-network-interface --attachment-id ${attachment_id} 
         sleep ${OCF_RESKEY_wait}
-	#sleep 10
     fi
     return $OCF_SUCCESS
 }

--- a/eni
+++ b/eni
@@ -130,6 +130,12 @@ eni_start() {
     if [ $? =  $OCF_SUCCESS ]; then
 	return $OCF_SUCCESS
     fi
+     
+    #Detach existing
+    attachment_id=`/usr/bin/aws ec2 describe-network-interfaces --network-interface-ids ${OCF_RESKEY_interface_id} --query 'NetworkInterfaces[0].Attachment' --output json | grep \"AttachmentId\": | sed -e 's/'.*\"AttachmentId\"':\s\"\(.*\)\"\,\s$/\1/'`
+    /usr/bin/aws ec2 detach-network-interface --attachment-id ${attachment_id}
+    sleep 15
+
     /usr/bin/aws ec2 attach-network-interface --network-interface-id ${OCF_RESKEY_interface_id} --instance-id ${instance_id} --device-index ${OCF_RESKEY_device_index}
     #sleep ${OCF_RESKEY_wait}
     sleep 5

--- a/eni
+++ b/eni
@@ -134,7 +134,7 @@ eni_start() {
     #sleep ${OCF_RESKEY_wait}
     sleep 5
 
-    private_ip="10.0.105.21"
+    private_ip="10.0.106.25"
     private_ip_netmask="255.255.252.0"
 
     /sbin/ifconfig ${OCF_RESKEY_device_name} ${private_ip} netmask ${private_ip_netmask} up

--- a/eni
+++ b/eni
@@ -134,11 +134,10 @@ eni_start() {
     #Detach existing
     attachment_id=`/usr/bin/aws ec2 describe-network-interfaces --network-interface-ids ${OCF_RESKEY_interface_id} --query 'NetworkInterfaces[0].Attachment' --output json | grep \"AttachmentId\": | sed -e 's/'.*\"AttachmentId\"':\s\"\(.*\)\"\,\s$/\1/'`
     /usr/bin/aws ec2 detach-network-interface --attachment-id ${attachment_id}
-    sleep 15
+    sleep ${OCF_RESKEY_wait}
 
     /usr/bin/aws ec2 attach-network-interface --network-interface-id ${OCF_RESKEY_interface_id} --instance-id ${instance_id} --device-index ${OCF_RESKEY_device_index}
-    #sleep ${OCF_RESKEY_wait}
-    sleep 5
+    sleep ${OCF_RESKEY_wait}
 
     private_ip="10.0.106.25"
     private_ip_netmask="255.255.252.0"
@@ -151,17 +150,17 @@ eni_start() {
 }
 
 eni_stop() {
-    #eni_monitor
-    #if [ $? =  $OCF_SUCCESS ]; then
+    eni_monitor
+    if [ $? =  $OCF_SUCCESS ]; then
         #ip rule del table ${OCF_RESKEY_table_id}
-	#This doesn't work if the stop doesn't occur on the active machine
-        #attachment_id=`/usr/bin/aws ec2 describe-network-interfaces --network-interface-ids ${OCF_RESKEY_interface_id} --filter "Name=attachment.instance-id, Values=${instance_id}" --output json | grep \"AttachmentId\": | sed -e 's/'.*\"AttachmentId\"':\s\"\(.*\)\"\,\s$/\1/'`
-        attachment_id=`/usr/bin/aws ec2 describe-network-interfaces --network-interface-ids ${OCF_RESKEY_interface_id} --query 'NetworkInterfaces[0].Attachment' --output json | grep \"AttachmentId\": | sed -e 's/'.*\"AttachmentId\"':\s\"\(.*\)\"\,\s$/\1/'`
+	#This doesn't work if the stop doesn't occur on the active machine -- need to determine if that matters,reverting for now.
+        attachment_id=`/usr/bin/aws ec2 describe-network-interfaces --network-interface-ids ${OCF_RESKEY_interface_id} --filter "Name=attachment.instance-id, Values=${instance_id}" --output json | grep \"AttachmentId\": | sed -e 's/'.*\"AttachmentId\"':\s\"\(.*\)\"\,\s$/\1/'`
+        #attachment_id=`/usr/bin/aws ec2 describe-network-interfaces --network-interface-ids ${OCF_RESKEY_interface_id} --query 'NetworkInterfaces[0].Attachment' --output json | grep \"AttachmentId\": | sed -e 's/'.*\"AttachmentId\"':\s\"\(.*\)\"\,\s$/\1/'`
 	
         /usr/bin/aws ec2 detach-network-interface --attachment-id ${attachment_id} 
-        #sleep ${OCF_RESKEY_wait}
-	sleep 10
-    #fi
+        sleep ${OCF_RESKEY_wait}
+	#sleep 10
+    fi
     return $OCF_SUCCESS
 }
 

--- a/eni
+++ b/eni
@@ -148,7 +148,10 @@ eni_stop() {
     eni_monitor
     if [ $? =  $OCF_SUCCESS ]; then
         #ip rule del table ${OCF_RESKEY_table_id}
-        attachment_id=`/usr/bin/aws ec2 describe-network-interfaces --network-interface-ids ${OCF_RESKEY_interface_id} --filter "Name=attachment.instance-id, Values=${instance_id}" --output json | grep \"AttachmentId\": | sed -e 's/'.*\"AttachmentId\"':\s\"\(.*\)\"\,\s$/\1/'`
+	#This doesn't work if the stop doesn't occur on the active machine
+        #attachment_id=`/usr/bin/aws ec2 describe-network-interfaces --network-interface-ids ${OCF_RESKEY_interface_id} --filter "Name=attachment.instance-id, Values=${instance_id}" --output json | grep \"AttachmentId\": | sed -e 's/'.*\"AttachmentId\"':\s\"\(.*\)\"\,\s$/\1/'`
+        attachment_id=`/usr/bin/aws ec2 describe-network-interfaces --network-interface-ids ${OCF_RESKEY_interface_id} --query 'NetworkInterfaces[0].Attachment' --output json | grep \"AttachmentId\": | sed -e 's/'.*\"AttachmentId\"':\s\"\(.*\)\"\,\s$/\1/'`
+	
         /usr/bin/aws ec2 detach-network-interface --attachment-id ${attachment_id} 
         #sleep ${OCF_RESKEY_wait}
 	sleep 10

--- a/eni
+++ b/eni
@@ -70,6 +70,23 @@ The name of the device for the network interface attachment.
 <content type="string" default="eth1" />
 </parameter>
 
+<parameter name="private_ip" required="1">
+<longdesc lang="en">
+The private ip address for the network interface attachment.
+</longdesc>
+<shortdesc lang="en">private ip</shortdesc>
+<content type="string" />
+</parameter>
+
+<parameter name="netmask" required="1">
+<longdesc lang="en">
+The netmask for the network interface attachment.
+</longdesc>
+<shortdesc lang="en">netmask</shortdesc>
+<content type="string" />
+</parameter>
+
+
 <parameter name="gateway" required="1">
 <longdesc lang="en">
 The gateway of the device for the network interface attachment.
@@ -139,10 +156,11 @@ eni_start() {
     /usr/bin/aws ec2 attach-network-interface --network-interface-id ${OCF_RESKEY_interface_id} --instance-id ${instance_id} --device-index ${OCF_RESKEY_device_index}
     sleep ${OCF_RESKEY_wait}
 
-    private_ip="10.0.106.25"
-    private_ip_netmask="255.255.252.0"
+    #private_ip="10.0.106.25"
+    #private_ip_netmask="255.255.252.0"
 
-    /sbin/ifconfig ${OCF_RESKEY_device_name} ${private_ip} netmask ${private_ip_netmask} up
+    #/sbin/ifconfig ${OCF_RESKEY_device_name} ${private_ip} netmask ${private_ip_netmask} up
+    /sbin/ifconfig ${OCF_RESKEY_device_name} ${OCF_RESKEY_private_ip} netmask ${OCF_RESKEY_netmask} up
 
     #private_ip=`ifconfig ${OCF_RESKEY_device_name} | grep "inet addr:" | awk -F: '{ print $2 }' | awk '{ print $1 }'`
     #ip rule add from ${private_ip} table ${OCF_RESKEY_table_id} prio ${OCF_RESKEY_table_priority}

--- a/eni
+++ b/eni
@@ -158,7 +158,10 @@ eni_start() {
 
     /sbin/ifconfig ${OCF_RESKEY_device_name} ${OCF_RESKEY_private_ip} netmask ${OCF_RESKEY_netmask} up
 
-    #private_ip=`ifconfig ${OCF_RESKEY_device_name} | grep "inet addr:" | awk -F: '{ print $2 }' | awk '{ print $1 }'`
+    ip rule add from ${OCF_RESKEY_private_ip} table ${OCF_RESKEY_table_id} prio ${OCF_RESKEY_table_priority}
+    ip route add default via ${OCF_RESKEY_gateway} dev ${OCF_RESKEY_device_name} table ${OCF_RESKEY_table_id}
+    ip route add default via ${OCF_RESKEY_gateway} dev ${OCF_RESKEY_device_name} metric ${OCF_RESKEY_table_priority}
+
     #ip rule add from ${private_ip} table ${OCF_RESKEY_table_id} prio ${OCF_RESKEY_table_priority}
     #ip route add via ${OCF_RESKEY_gateway} dev ${OCF_RESKEY_device_name} src ${private_ip} table ${OCF_RESKEY_table_id}
 }
@@ -166,6 +169,9 @@ eni_start() {
 eni_stop() {
     eni_monitor
     if [ $? =  $OCF_SUCCESS ]; then
+	ip rule delete from ${OCF_RESKEY_private_ip} table ${OCF_RESKEY_table_id} prio ${OCF_RESKEY_table_priority}
+    	ip route delete default via ${OCF_RESKEY_gateway} dev ${OCF_RESKEY_device_name} table ${OCF_RESKEY_table_id}
+    	ip route delete default via ${OCF_RESKEY_gateway} dev ${OCF_RESKEY_device_name} metric ${OCF_RESKEY_table_priority}
         #ip rule del table ${OCF_RESKEY_table_id}
 	#This doesn't work if the stop doesn't occur on the active machine -- need to determine if that matters,reverting for now.
         attachment_id=`/usr/bin/aws ec2 describe-network-interfaces --network-interface-ids ${OCF_RESKEY_interface_id} --filter "Name=attachment.instance-id, Values=${instance_id}" --output json | grep \"AttachmentId\": | sed -e 's/'.*\"AttachmentId\"':\s\"\(.*\)\"\,\s$/\1/'`

--- a/eni
+++ b/eni
@@ -158,21 +158,22 @@ eni_start() {
 
     /sbin/ifconfig ${OCF_RESKEY_device_name} ${OCF_RESKEY_private_ip} netmask ${OCF_RESKEY_netmask} up
 
+    # These multihomed routing additions were needed because the CentOS AMI didn't have the necessary hotplug support.
+    # Depending on the specific AMI used, they may not be necessary
     ip rule add from ${OCF_RESKEY_private_ip} table ${OCF_RESKEY_table_id} prio ${OCF_RESKEY_table_priority}
     ip route add default via ${OCF_RESKEY_gateway} dev ${OCF_RESKEY_device_name} table ${OCF_RESKEY_table_id}
     ip route add default via ${OCF_RESKEY_gateway} dev ${OCF_RESKEY_device_name} metric ${OCF_RESKEY_table_priority}
 
-    #ip rule add from ${private_ip} table ${OCF_RESKEY_table_id} prio ${OCF_RESKEY_table_priority}
-    #ip route add via ${OCF_RESKEY_gateway} dev ${OCF_RESKEY_device_name} src ${private_ip} table ${OCF_RESKEY_table_id}
 }
 
 eni_stop() {
     eni_monitor
     if [ $? =  $OCF_SUCCESS ]; then
+	# These multihomed routing additions were needed because the CentOS AMI didn't have the necessary hotplug support.
+        # Depending on the specific AMI used, they may not be necessary
 	ip rule delete from ${OCF_RESKEY_private_ip} table ${OCF_RESKEY_table_id} prio ${OCF_RESKEY_table_priority}
     	ip route delete default via ${OCF_RESKEY_gateway} dev ${OCF_RESKEY_device_name} table ${OCF_RESKEY_table_id}
     	ip route delete default via ${OCF_RESKEY_gateway} dev ${OCF_RESKEY_device_name} metric ${OCF_RESKEY_table_priority}
-        #ip rule del table ${OCF_RESKEY_table_id}
 	#This doesn't work if the stop doesn't occur on the active machine -- need to determine if that matters,reverting for now.
         attachment_id=`/usr/bin/aws ec2 describe-network-interfaces --network-interface-ids ${OCF_RESKEY_interface_id} --filter "Name=attachment.instance-id, Values=${instance_id}" --output json | grep \"AttachmentId\": | sed -e 's/'.*\"AttachmentId\"':\s\"\(.*\)\"\,\s$/\1/'`
         #attachment_id=`/usr/bin/aws ec2 describe-network-interfaces --network-interface-ids ${OCF_RESKEY_interface_id} --query 'NetworkInterfaces[0].Attachment' --output json | grep \"AttachmentId\": | sed -e 's/'.*\"AttachmentId\"':\s\"\(.*\)\"\,\s$/\1/'`

--- a/eni
+++ b/eni
@@ -150,7 +150,8 @@ eni_stop() {
         #ip rule del table ${OCF_RESKEY_table_id}
         attachment_id=`/usr/bin/aws ec2 describe-network-interfaces --network-interface-ids ${OCF_RESKEY_interface_id} --filter "Name=attachment.instance-id, Values=${instance_id}" --output json | grep \"AttachmentId\": | sed -e 's/'.*\"AttachmentId\"':\s\"\(.*\)\"\,\s$/\1/'`
         /usr/bin/aws ec2 detach-network-interface --attachment-id ${attachment_id} 
-        sleep ${OCF_RESKEY_wait}
+        #sleep ${OCF_RESKEY_wait}
+	sleep 5
     fi
     return $OCF_SUCCESS
 }

--- a/eni
+++ b/eni
@@ -131,17 +131,23 @@ eni_start() {
 	return $OCF_SUCCESS
     fi
     /usr/bin/aws ec2 attach-network-interface --network-interface-id ${OCF_RESKEY_interface_id} --instance-id ${instance_id} --device-index ${OCF_RESKEY_device_index}
-    sleep ${OCF_RESKEY_wait}
+    #sleep ${OCF_RESKEY_wait}
+    sleep 5
 
-    private_ip=`ifconfig ${OCF_RESKEY_device_name} | grep "inet addr:" | awk -F: '{ print $2 }' | awk '{ print $1 }'`
-    ip rule add from ${private_ip} table ${OCF_RESKEY_table_id} prio ${OCF_RESKEY_table_priority}
-    ip route add via ${OCF_RESKEY_gateway} dev ${OCF_RESKEY_device_name} src ${private_ip} table ${OCF_RESKEY_table_id}
+    private_ip="10.0.105.21"
+    private_ip_netmask="255.255.252.0"
+
+    /sbin/ifconfig ${OCF_RESKEY_device_name} ${private_ip} netmask ${private_ip_netmask} up
+
+    #private_ip=`ifconfig ${OCF_RESKEY_device_name} | grep "inet addr:" | awk -F: '{ print $2 }' | awk '{ print $1 }'`
+    #ip rule add from ${private_ip} table ${OCF_RESKEY_table_id} prio ${OCF_RESKEY_table_priority}
+    #ip route add via ${OCF_RESKEY_gateway} dev ${OCF_RESKEY_device_name} src ${private_ip} table ${OCF_RESKEY_table_id}
 }
 
 eni_stop() {
     eni_monitor
     if [ $? =  $OCF_SUCCESS ]; then
-        ip rule del table ${OCF_RESKEY_table_id}
+        #ip rule del table ${OCF_RESKEY_table_id}
         attachment_id=`/usr/bin/aws ec2 describe-network-interfaces --network-interface-ids ${OCF_RESKEY_interface_id} --filter "Name=attachment.instance-id, Values=${instance_id}" --output json | grep \"AttachmentId\": | sed -e 's/'.*\"AttachmentId\"':\s\"\(.*\)\"\,\s$/\1/'`
         /usr/bin/aws ec2 detach-network-interface --attachment-id ${attachment_id} 
         sleep ${OCF_RESKEY_wait}

--- a/eni
+++ b/eni
@@ -145,8 +145,8 @@ eni_start() {
 }
 
 eni_stop() {
-    eni_monitor
-    if [ $? =  $OCF_SUCCESS ]; then
+    #eni_monitor
+    #if [ $? =  $OCF_SUCCESS ]; then
         #ip rule del table ${OCF_RESKEY_table_id}
 	#This doesn't work if the stop doesn't occur on the active machine
         #attachment_id=`/usr/bin/aws ec2 describe-network-interfaces --network-interface-ids ${OCF_RESKEY_interface_id} --filter "Name=attachment.instance-id, Values=${instance_id}" --output json | grep \"AttachmentId\": | sed -e 's/'.*\"AttachmentId\"':\s\"\(.*\)\"\,\s$/\1/'`
@@ -155,7 +155,7 @@ eni_stop() {
         /usr/bin/aws ec2 detach-network-interface --attachment-id ${attachment_id} 
         #sleep ${OCF_RESKEY_wait}
 	sleep 10
-    fi
+    #fi
     return $OCF_SUCCESS
 }
 


### PR DESCRIPTION
Hello--

I recently stumbled on your code and it really jumpstarted my project.
If you're interested, here are the modifications I made to make it compatible with RHEL/CentOS 7.x
If nothing else, I would look at the logic added to ensure that the ENI is detatched (presumably from the failed node) before attaching (on the new node). As I tested around with your original code, the transition would fail because the attach-network-interface call would fail (already attached).

Thanks again for putting this out there - huge help!
